### PR TITLE
Main form / button view fixes and improvements

### DIFF
--- a/Tube/App.config
+++ b/Tube/App.config
@@ -24,6 +24,9 @@
       <setting name="RawKeyNames" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="ViewButtons" serializeAs="String">
+        <value>False</value>
+      </setting>
     </Glue.Properties.Settings>
   </userSettings>
 </configuration>

--- a/Tube/Forms/ViewButtons.Designer.cs
+++ b/Tube/Forms/ViewButtons.Designer.cs
@@ -39,22 +39,23 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxButtonStates.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.textBoxButtonStates.Cursor = System.Windows.Forms.Cursors.Default;
-            this.textBoxButtonStates.Location = new System.Drawing.Point(11, 11);
-            this.textBoxButtonStates.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxButtonStates.Location = new System.Drawing.Point(22, 21);
+            this.textBoxButtonStates.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.textBoxButtonStates.Multiline = true;
             this.textBoxButtonStates.Name = "textBoxButtonStates";
             this.textBoxButtonStates.ReadOnly = true;
-            this.textBoxButtonStates.Size = new System.Drawing.Size(104, 224);
+            this.textBoxButtonStates.Size = new System.Drawing.Size(112, 547);
             this.textBoxButtonStates.TabIndex = 0;
             // 
             // ViewButtons
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(126, 246);
+            this.ClientSize = new System.Drawing.Size(368, 589);
+            this.ControlBox = false;
             this.Controls.Add(this.textBoxButtonStates);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "ViewButtons";

--- a/Tube/Forms/ViewButtons.cs
+++ b/Tube/Forms/ViewButtons.cs
@@ -13,6 +13,15 @@ namespace Glue.Forms
             InitializeComponent();
         }
 
+        protected override void OnFormClosing(FormClosingEventArgs e)
+        {
+            e.Cancel = true;
+
+            Hide();
+
+            base.OnFormClosing(e);
+        }
+
         protected override void OnActivated(EventArgs e)
         {
             WindowHandleUtils.HideCaret(this.textBoxButtonStates.Handle);

--- a/Tube/GlobalSuppressions.cs
+++ b/Tube/GlobalSuppressions.cs
@@ -1,0 +1,6 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+

--- a/Tube/Properties/Settings.Designer.cs
+++ b/Tube/Properties/Settings.Designer.cs
@@ -46,5 +46,17 @@ namespace Glue.Properties {
                 this["RawKeyNames"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ViewButtons {
+            get {
+                return ((bool)(this["ViewButtons"]));
+            }
+            set {
+                this["ViewButtons"] = value;
+            }
+        }
     }
 }

--- a/Tube/Properties/Settings.settings
+++ b/Tube/Properties/Settings.settings
@@ -8,5 +8,8 @@
     <Setting Name="RawKeyNames" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="ViewButtons" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Tube/native/KeyboardInterceptor.cs
+++ b/Tube/native/KeyboardInterceptor.cs
@@ -16,8 +16,8 @@ namespace Glue.Native
     {
         private static readonly log4net.ILog LOGGER = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        private static readonly LowLevelKeyboardProc s_proc = HookCallback;
-        private static LowLevelKeyboardProc s_handler = null;
+        private static readonly LowLevelKeyboardProc s_proc = HookCallback; // registered as hook proc via SetHook
+        private static LowLevelKeyboardProc s_handler = null;               // for specific implementation
         private static IntPtr s_hookID = IntPtr.Zero;
 
         public static void Initialize(LowLevelKeyboardProc lowLevelKeyboardProc)


### PR DESCRIPTION
* Fixed broken persistence (settings weren't saving since main form was being hidden instead of closed).
* Button state view option is now a persistent property, and form is shown when app starts.
* Button state form hides instead of closing so position etc. persists.
* Removed X button from button state form because it caused no end of grief. Only show / hide this one via the menu!