### PR TITLE
Bug fix: Multiple triggers may be bound to the same key

### DIFF
--- a/Tube/JsonWrapper.cs
+++ b/Tube/JsonWrapper.cs
@@ -31,11 +31,18 @@ namespace Glue
         /// <param name="keyMap"></param>
         /// <param name="macros"></param>
         public JsonWrapper(
-            Dictionary<Keys, Trigger> triggers,
+            TriggerMap triggers,
             Dictionary<VirtualKeyCode, KeyboardRemapEntry> keyMap,
             Dictionary<string, Macro> macros)
         {
-            this.Triggers = new List<Trigger>(triggers.Values);
+            this.Triggers = new List<Trigger>();
+
+            // Flatten trigger map into easily serializable list
+            foreach (List<Trigger> triggerList in triggers.Values)
+            {
+                this.Triggers.AddRange(triggerList);
+            }
+
             this.RemapKeys = new List<KeyboardRemapEntry>(keyMap.Values);
             this.Macros = new List<Macro>(macros.Values);
         }
@@ -47,13 +54,13 @@ namespace Glue
         {
         }
 
-        public Dictionary<Keys, Trigger> GetTriggerMap()
+        public TriggerMap GetTriggerMap()
         {
-            Dictionary<Keys, Trigger> triggerMap = new Dictionary<Keys, Trigger>(Triggers.Count);
+            TriggerMap triggerMap = new TriggerMap(this.Triggers.Count);
 
             foreach (Trigger trigger in Triggers)
             {
-                triggerMap.Add(trigger.TriggerKey, trigger);
+                triggerMap.Add(trigger);
             }
 
             return triggerMap;

--- a/Tube/Trigger.cs
+++ b/Tube/Trigger.cs
@@ -119,7 +119,7 @@ namespace Glue
             return formattedList;
         }
 
-        internal bool Fire()
+        internal bool CheckAndFire()
         {
             if (!AreModKeysActive())
             {

--- a/Tube/Triggers.cs
+++ b/Tube/Triggers.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace Glue 
+{
+    class TriggerMap : Dictionary<Keys, List<Trigger>>
+    {
+        public TriggerMap(int initialCount) : base(initialCount)
+        {
+        }
+
+        public TriggerMap() : base()
+        {
+        }
+
+        public void Add(Trigger trigger)
+        {
+            if (!TryGetValue(trigger.TriggerKey, out List<Trigger> triggerList))
+            {
+                triggerList = new List<Trigger>();
+                Add(trigger.TriggerKey, triggerList);
+            }
+            triggerList.Add(trigger);
+        }
+    }
+}

--- a/Tube/Tube.csproj
+++ b/Tube/Tube.csproj
@@ -144,6 +144,7 @@
     <Compile Include="PropertyIO\PropertyString.cs" />
     <Compile Include="TrayApplicationContext.cs" />
     <Compile Include="PropertyIO\FormatDuration.cs" />
+    <Compile Include="Triggers.cs" />
     <Compile Include="WindowsInput\InputBuilder.cs" />
     <Compile Include="Priority_Queue\IPriorityQueue.cs" />
     <Compile Include="Native\Keyboard.cs" />


### PR DESCRIPTION
* Trigger Dictionary used to be <Keys, Trigger>, now is <Keys, List<Trigger>>
* Added wrapper for Dictionary called Triggers for easier access.
* Multiple triggers may fire on the same keystroke. Eating input is an OR operation between firing triggers, so if any trigger designates that the input must be eaten, it will be eaten.
* Order of triggers is undefined when more than one is fired by the same keystroke. List order is affected by de/serialization, and would need a priority feature and sort them by priority or time.
* Serialized json format shouldn't need to change with this fix.